### PR TITLE
cargo: Use more secure random generator crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,4 +89,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings
+          args: --all-targets --all-features -- -D warnings -A clippy::derive_partial_eq_without_eq

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,14 @@ hmac = ">=0.12"
 josekit = { version = ">=0.7", optional = true }
 lazy_static = ">=1.4"
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "1ba0d94a900a97aa1bcac032a67ea23766bcfdef" }
+openssl = ">=0.10"
 pin-project-lite = "0.2.9"
 prost = { version = ">=0.11.0", optional = true }
-rand = ">=0.8"
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = ">=1.0"
 sha2 = ">=0.10"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"], optional = true }
 tonic = { version = ">=0.8.0", optional = true }
-
-[dev-dependencies]
-openssl = ">=0.10"
 
 [build-dependencies]
 tonic-build = {version = ">=0.7.0", optional = true }

--- a/src/blockcipher/aes_ctr.rs
+++ b/src/blockcipher/aes_ctr.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use ctr::cipher::generic_array::GenericArray;
 use ctr::cipher::{KeyIvInit, StreamCipher};
 use hmac::{Hmac, Mac};
-use rand::{thread_rng, Rng};
+use openssl::rand::rand_bytes;
 use sha2::Sha256;
 
 use crate::blockcipher::{EncryptionFinalizer, LayerBlockCipher, LayerBlockCipherOptions};
@@ -75,7 +75,7 @@ impl<R> AESCTRBlockCipher<R> {
                 }
                 nonce = v;
             }
-            None => thread_rng().try_fill(&mut nonce[..])?,
+            None => rand_bytes(&mut nonce[..])?,
         }
 
         let cipher = Aes256Ctr::new(
@@ -106,7 +106,7 @@ impl<R> AESCTRBlockCipher<R> {
 impl<R> LayerBlockCipher<R> for AESCTRBlockCipher<R> {
     fn generate_key(&self) -> Result<Vec<u8>> {
         let mut key = vec![0; self.key_len];
-        thread_rng().try_fill(&mut key[..])?;
+        rand_bytes(&mut key[..])?;
         Ok(key)
     }
 
@@ -413,10 +413,10 @@ mod tests {
         let layer_data: Vec<u8> = b"this is some data".to_vec();
 
         let mut symmetric_key = vec![0; 32];
-        thread_rng().try_fill(&mut symmetric_key[..]).unwrap();
+        rand_bytes(&mut symmetric_key[..]).unwrap();
 
         let mut nonce = vec![0; 16];
-        thread_rng().try_fill(&mut nonce[..]).unwrap();
+        rand_bytes(&mut nonce[..]).unwrap();
 
         let mut crypto_encrypt = Aes256Ctr::new(
             GenericArray::from_slice(symmetric_key.as_slice()),


### PR DESCRIPTION
As described in: https://rust-random.github.io/book/guide-rngs.html#not-a-crypto-library
"It should be emphasised that this is not a cryptography library"
"It is therefore recommended to use specialized libraries where possible,
for example openssl, ring and the RustCrypto libraries."

Fixed issue in : https://github.com/confidential-containers/community/issues/44

Signed-off-by: Wang, Arron <arron.wang@intel.com>