### PR TITLE
fix: support eaa_kbc aa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,22 @@ jobs:
           - stable
           - beta
           - nightly
+
+    # Run all steps in the compilation testing containers
+    container:
+      image: runetest/compilation-testing:ubuntu18.04
+      env:
+        LD_LIBRARY_PATH: /usr/local/lib/rats-tls
+
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-
+      - name: Update cargo home
+        run: |
+          apt-get update && apt-get install -y cargo
+          cp -r /root/.cargo /github/home/.cargo
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
@@ -29,8 +39,14 @@ jobs:
 
       - name: Install tonic's protoc dependencies
         run: |
-          sudo apt install apt protobuf-compiler libprotobuf-dev
-
+          apt install apt protobuf-compiler libprotobuf-dev
+      - name: Build and install rats-tls
+        run: | 
+          apt-get install -y libcurl4-openssl-dev
+          git clone https://github.com/inclavare-containers/rats-tls
+          cd rats-tls
+          cmake -DBUILD_SAMPLES=on -H. -Bbuild
+          make -C build install
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,16 @@ serde_json = ">=1.0"
 sha2 = ">=0.10"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"], optional = true }
 tonic = { version = ">=0.8.0", optional = true }
-attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent" }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent", rev = "3b4716dd3d8bbf0d5f8cec7bc0d528421f00fd06", optional = true  }
 
 [build-dependencies]
 tonic-build = {version = "0.8.0", optional = true }
 
 [features]
 default = ["keywrap-jwe", "keywrap-keyprovider"]
+eaa_kbc = ["keywrap-jwe", "keywrap-keyprovider", "attestation_agent/eaa_kbc"]
 async-io = ["futures", "tokio"]
 keywrap-jwe = ["josekit"]
-keywrap-keyprovider = ["aes-gcm", "futures", "tokio", "tonic-build", "utils-runner", "utils-keyprovider"]
+keywrap-keyprovider = ["aes-gcm", "futures", "tokio", "tonic-build", "utils-runner", "utils-keyprovider", "attestation_agent"]
 utils-runner = []
 utils-keyprovider = ["prost", "tonic"]


### PR DESCRIPTION
In the default, the AA uses `sample_kbc` which is just a demo kbc.  To leverage `eaa_kbc`, we add a new feature to export it.

Signed-off-by: haokun.xing <haokun.xin@intel.com>