### PR TITLE
encryption: export stream API for decrypt layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ futures = { version = "0.3.21", optional = true }
 hmac = ">=0.12"
 josekit = { version = ">=0.7", optional = true }
 lazy_static = ">=1.4"
-oci-distribution = "0.9.3"
+oci-distribution = "0.9.4"
 openssl = { version = ">=0.10", features = ["vendored"] }
 pin-project-lite = "0.2.9"
 prost = { version = ">=0.11.0", optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -329,7 +329,7 @@ mod tests {
         assert!(dc.decrypt_with_gpg(priv_keys1, priv_keys2).is_ok());
         assert!(dc.decrypt_with_pkcs11(pkcs11_config, pkcs11_yaml).is_ok());
         assert!(dc.decrypt_with_key_provider(key_providers).is_ok());
-        println!("final decrypt config is: {:?}", dc);
+        println!("final decrypt config is: {dc:?}");
     }
 
     #[test]
@@ -371,7 +371,7 @@ mod tests {
         assert_eq!(vec![b"abc".to_vec()], ec.param["key_p2"]);
         assert_eq!(vec![b"abc:abc".to_vec()], ec.param["key_p3"]);
 
-        println!("final encrypt config is: {:?}", ec);
+        println!("final encrypt config is: {ec:?}");
     }
 
     #[test]
@@ -393,7 +393,7 @@ mod tests {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("data");
         let test_conf_path = format!("{}/{}", path.to_str().unwrap(), "ocicrypt_config.json");
-        env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", &test_conf_path);
+        env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", test_conf_path);
 
         let mut provider = HashMap::new();
         let args: Vec<String> = Vec::default();

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -236,7 +236,8 @@ fn get_layer_key_opts(
     .cloned()
 }
 
-fn decrypt_layer_key_opts_data(dc: &DecryptConfig, desc: &OciDescriptor) -> Result<Vec<u8>> {
+/// Unwrap layer decryption key from OCI descriptor annotations.
+pub fn decrypt_layer_key_opts_data(dc: &DecryptConfig, desc: &OciDescriptor) -> Result<Vec<u8>> {
     let mut priv_key_given = false;
 
     for (annotations_id, scheme) in KEY_WRAPPERS_ANNOTATIONS.iter() {
@@ -341,6 +342,32 @@ pub fn decrypt_layer<R: Read>(
     Ok((Some(lbch), opts.private.digest))
 }
 
+/// This is a streaming version of [`decrypt_layer`].
+///
+/// priv_opts_data can get from [`decrypt_layer_key_opts_data`]
+#[cfg(feature = "async-io")]
+pub fn async_decrypt_layer<R: tokio::io::AsyncRead>(
+    layer_reader: R,
+    desc: &OciDescriptor,
+    priv_opts_data: &[u8],
+) -> Result<(impl tokio::io::AsyncRead, String)> {
+    let pub_opts_data = get_layer_pub_opts(desc)?;
+
+    let priv_opts: PrivateLayerBlockCipherOptions = serde_json::from_slice(priv_opts_data)?;
+    let mut lbch = LayerBlockCipherHandler::new()?;
+
+    let pub_opts: PublicLayerBlockCipherOptions = serde_json::from_slice(&pub_opts_data)?;
+
+    let mut opts = LayerBlockCipherOptions {
+        public: pub_opts,
+        private: priv_opts,
+    };
+
+    lbch.decrypt(layer_reader, &mut opts)?;
+
+    Ok((lbch, opts.private.digest))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -393,6 +420,59 @@ mod tests {
             let mut decryptor = layer_decryptor.unwrap();
 
             assert!(decryptor.read_to_end(&mut plaintxt_data).is_ok());
+            assert_eq!(layer_data, plaintxt_data);
+            assert_eq!(digest, dec_digest);
+        }
+    }
+
+    #[cfg(feature = "async-io")]
+    #[tokio::test]
+    async fn test_async_decrypt_layer() {
+        let path = load_data_path();
+        let test_conf_path = format!("{}/{}", path, "ocicrypt_config.json");
+        env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", &test_conf_path);
+
+        let pub_key_file = format!("{}/{}", path, "public_key.pem");
+        let pub_key = fs::read(&pub_key_file).unwrap();
+
+        let priv_key_file = format!("{}/{}", path, "private_key.pem");
+        let priv_key = fs::read(&priv_key_file).unwrap();
+
+        let mut ec = EncryptConfig::default();
+        assert!(ec.encrypt_with_jwe(vec![pub_key]).is_ok());
+
+        let mut dc = DecryptConfig::default();
+        assert!(dc
+            .decrypt_with_priv_keys(vec![priv_key.to_vec()], vec![vec![]])
+            .is_ok());
+
+        let layer_data: Vec<u8> = b"This is some text!".to_vec();
+        let mut desc = OciDescriptor::default();
+        let digest = format!("sha256:{:x}", Sha256::digest(&layer_data));
+        desc.digest = digest.clone();
+
+        let (layer_encryptor, mut elf) = encrypt_layer(&ec, layer_data.as_slice(), &desc).unwrap();
+
+        let mut encrypted_data: Vec<u8> = Vec::new();
+        let mut encryptor = layer_encryptor.unwrap();
+        assert!(encryptor.read_to_end(&mut encrypted_data).is_ok());
+        assert!(encryptor.finalized_lbco(&mut elf.lbco).is_ok());
+
+        if let Ok(new_annotations) = elf.finalized_annotations(&ec, &desc, Some(&mut encryptor)) {
+            let new_desc = OciDescriptor {
+                annotations: Some(new_annotations),
+                ..Default::default()
+            };
+            let key_opts = decrypt_layer_key_opts_data(&dc, &new_desc).unwrap();
+
+            let (mut async_reader, dec_digest) =
+                async_decrypt_layer(encrypted_data.as_slice(), &new_desc, &key_opts).unwrap();
+
+            let mut plaintxt_data: Vec<u8> = Vec::new();
+            tokio::io::AsyncReadExt::read_to_end(&mut async_reader, &mut plaintxt_data)
+                .await
+                .unwrap();
+
             assert_eq!(layer_data, plaintxt_data);
             assert_eq!(digest, dec_digest);
         }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -380,13 +380,13 @@ mod tests {
     fn test_encrypt_decrypt_layer() {
         let path = load_data_path();
         let test_conf_path = format!("{}/{}", path, "ocicrypt_config.json");
-        env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", &test_conf_path);
+        env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", test_conf_path);
 
         let pub_key_file = format!("{}/{}", path, "public_key.pem");
-        let pub_key = fs::read(&pub_key_file).unwrap();
+        let pub_key = fs::read(pub_key_file).unwrap();
 
         let priv_key_file = format!("{}/{}", path, "private_key.pem");
-        let priv_key = fs::read(&priv_key_file).unwrap();
+        let priv_key = fs::read(priv_key_file).unwrap();
 
         let mut ec = EncryptConfig::default();
         assert!(ec.encrypt_with_jwe(vec![pub_key.clone()]).is_ok());

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -345,7 +345,7 @@ mod tests {
 
         let private_keys = format!("{}/{}", path, "private_key.pem");
         let pwd_file = format!("file={}/{}", path, "passwordfile");
-        let keyfiles_and_pwds = format!("{}:{}", private_keys, pwd_file);
+        let keyfiles_and_pwds = format!("{private_keys}:{pwd_file}");
 
         assert!(process_private_keyfiles(vec![private_keys]).is_ok());
         assert!(process_private_keyfiles(vec![keyfiles_and_pwds]).is_ok());

--- a/src/keywrap/keyprovider.rs
+++ b/src/keywrap/keyprovider.rs
@@ -197,7 +197,7 @@ impl KeyProviderKeyWrapper {
     ) -> Self {
         if let Some(grpc) = &attrs.grpc {
             if !grpc.starts_with("http://") && !grpc.starts_with("tcp://") {
-                attrs.grpc = Some(format!("http://{}", grpc));
+                attrs.grpc = Some(format!("http://{grpc}"));
             }
         }
 
@@ -705,7 +705,7 @@ mod tests {
 
             tokio::spawn(async move {
                 if let Err(e) = serve.await {
-                    eprintln!("Error = {:?}", e);
+                    eprintln!("Error = {e:?}");
                 }
 
                 tx.send(()).unwrap();


### PR DESCRIPTION
This API will be an adaptor for input encrypted stream and
return decrypted stream. It will be easy to integrate into
Rust's asynchronous IO types.