### PR TITLE
encryption: Remove dependency of oci-distribution crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ futures = { version = "0.3.21", optional = true }
 hmac = ">=0.12"
 josekit = { version = ">=0.7", optional = true }
 lazy_static = ">=1.4"
-oci-distribution = "0.9.4"
 openssl = { version = ">=0.10", features = ["vendored"] }
 pin-project-lite = "0.2.9"
 prost = { version = ">=0.11.0", optional = true }


### PR DESCRIPTION
The only reason we use oci-distribution crate in ocicrypt-rs is using OciDescriptor struct and annotations(HashMap) and digest(String) data field. To reduce too many dependency, we can use them directly.

Signed-off-by: Wang, Arron <arron.wang@intel.com>