### PR TITLE
Reduce dependency by oci-crypt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,24 @@ jobs:
           command: test
           args: --no-default-features --features=keywrap-keyprovider-native
 
+      - name: Run cargo test - eaa-kbc
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=eaa_kbc
+
+      - name: Run cargo test - default
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+
+      - name: Run cargo test - all features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --all-features
+
       - name: Run cargo fmt check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,23 @@ jobs:
           command: test
           args: --no-default-features --features=keywrap-jwe
 
-      - name: Run cargo test - keywrap-keyprovider
+      - name: Run cargo test - keywrap-keyprovider-cmd
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features=keywrap-keyprovider
+          args: --no-default-features --features=keywrap-keyprovider-cmd
+
+      - name: Run cargo test - keywrap-keyprovider-grpc
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=keywrap-keyprovider-grpc
+
+      - name: Run cargo test - keywrap-keyprovider-native
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=keywrap-keyprovider-native
 
       - name: Run cargo fmt check
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ tonic-build = {version = "0.8.0", optional = true }
 aes-gcm = { version = "0.9.2" }
 
 [features]
-default = ["keywrap-jwe", "keywrap-keyprovider-cmd", "keywrap-keyprovider-grpc", "keywrap-keyprovider-native"]
-eaa_kbc = ["default", "attestation_agent/eaa_kbc"]
+default = ["keywrap-jwe", "keywrap-keyprovider-cmd"]
+eaa_kbc = ["keywrap-keyprovider-native", "attestation_agent/eaa_kbc"]
 async-io = ["tokio"]
 keywrap-jwe = ["josekit"]
 keywrap-keyprovider = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,9 @@ edition = "2018"
 [dependencies]
 anyhow = ">=1.0"
 aes = ">=0.8"
-aes-gcm = { version = "0.9.2", optional = true }
 base64 = "0.13"
 base64-serde = "0.6"
 ctr = ">=0.9"
-futures = { version = "0.3.21", optional = true }
 hmac = ">=0.12"
 josekit = { version = ">=0.7", optional = true }
 lazy_static = ">=1.4"
@@ -32,11 +30,15 @@ attestation_agent = { git = "https://github.com/confidential-containers/attestat
 [build-dependencies]
 tonic-build = {version = "0.8.0", optional = true }
 
+[dev-dependencies]
+aes-gcm = { version = "0.9.2" }
+
 [features]
-default = ["keywrap-jwe", "keywrap-keyprovider"]
-eaa_kbc = ["keywrap-jwe", "keywrap-keyprovider", "attestation_agent/eaa_kbc"]
-async-io = ["futures", "tokio"]
+default = ["keywrap-jwe", "keywrap-keyprovider-cmd", "keywrap-keyprovider-grpc", "keywrap-keyprovider-native"]
+eaa_kbc = ["default", "attestation_agent/eaa_kbc"]
+async-io = ["tokio"]
 keywrap-jwe = ["josekit"]
-keywrap-keyprovider = ["aes-gcm", "futures", "tokio", "tonic-build", "utils-runner", "utils-keyprovider", "attestation_agent"]
-utils-runner = []
-utils-keyprovider = ["prost", "tonic"]
+keywrap-keyprovider = []
+keywrap-keyprovider-cmd = ["keywrap-keyprovider"]
+keywrap-keyprovider-grpc = ["keywrap-keyprovider", "prost", "tonic", "tonic-build", "tokio/net"]
+keywrap-keyprovider-native = ["keywrap-keyprovider", "tokio/net", "tokio/sync", "attestation_agent"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ attestation_agent = { git = "https://github.com/confidential-containers/attestat
 tonic-build = {version = "0.8.0", optional = true }
 
 [dev-dependencies]
-aes-gcm = { version = "0.9.2" }
+aes-gcm = { version = "0.10" }
 
 [features]
 default = ["keywrap-jwe", "keywrap-keyprovider-cmd"]

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(feature = "keywrap-keyprovider")]
+    #[cfg(feature = "keywrap-keyprovider-grpc")]
     tonic_build::configure()
         .build_server(true)
         .out_dir("src/utils/")

--- a/src/blockcipher/aes_ctr.rs
+++ b/src/blockcipher/aes_ctr.rs
@@ -209,7 +209,10 @@ impl<R: tokio::io::AsyncRead> tokio::io::AsyncRead for AESCTRBlockCipher<R> {
         }
 
         let start_pos = buf.filled().len();
-        futures::ready!(reader.poll_read(cx, buf))?;
+        match reader.poll_read(cx, buf) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(res) => res?,
+        }
         let buf_filled = &mut buf.filled_mut()[start_pos..];
         if buf_filled.is_empty() {
             *done = true;

--- a/src/keywrap/keyprovider.rs
+++ b/src/keywrap/keyprovider.rs
@@ -480,7 +480,8 @@ mod tests {
         feature = "keywrap-keyprovider-grpc"
     ))]
     mod cmd_grpc {
-        use aes_gcm::aead::{Aead, NewAead};
+        use aes::{Aes256Dec, Aes256Enc};
+        use aes_gcm::aead::{Aead, KeyInit};
         use aes_gcm::{Aes256Gcm, Key, Nonce};
         use anyhow::{anyhow, Result};
 
@@ -488,7 +489,7 @@ mod tests {
         pub static mut DEC_KEY: &[u8; 32] = b"passphrasewhichneedstobe32bytes!";
 
         pub fn encrypt_key(plain_text: &[u8], encrypting_key: &[u8; 32]) -> Result<Vec<u8>> {
-            let encrypting_key = Key::from_slice(encrypting_key);
+            let encrypting_key = Key::<Aes256Enc>::from_slice(encrypting_key);
             let cipher = Aes256Gcm::new(encrypting_key);
             let nonce = Nonce::from_slice(b"unique nonce");
 
@@ -498,7 +499,7 @@ mod tests {
         }
 
         pub fn decrypt_key(cipher_text: &[u8], decrypting_key: &[u8; 32]) -> Result<Vec<u8>> {
-            let decrypting_key = Key::from_slice(decrypting_key);
+            let decrypting_key = Key::<Aes256Dec>::from_slice(decrypting_key);
             let cipher = Aes256Gcm::new(decrypting_key);
             let nonce = Nonce::from_slice(b"unique nonce");
 

--- a/src/keywrap/keyprovider.rs
+++ b/src/keywrap/keyprovider.rs
@@ -3,22 +3,21 @@
 
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
-use std::sync::Arc;
-use std::sync::Mutex;
 
 use anyhow::{anyhow, Result};
-use attestation_agent::{AttestationAPIs, AttestationAgent};
 use serde::Serialize;
-use tokio::runtime::{Builder, Runtime};
-use tonic::codegen::http::Uri;
 
-use crate::config::{Command, DecryptConfig, EncryptConfig, KeyProviderAttrs};
+use crate::config::{DecryptConfig, EncryptConfig, KeyProviderAttrs};
 use crate::keywrap::KeyWrapper;
-use crate::utils::{self, keyprovider as keyproviderpb, CommandExecuter};
+use crate::utils::{self, CommandExecuter};
 
+#[cfg(feature = "keywrap-keyprovider-native")]
+use attestation_agent::{AttestationAPIs, AttestationAgent};
+
+#[cfg(feature = "keywrap-keyprovider-native")]
 lazy_static! {
-    pub static ref ATTESTATION_AGENT: Arc<Mutex<AttestationAgent>> =
-        Arc::new(Mutex::new(AttestationAgent::new()));
+    pub static ref ATTESTATION_AGENT: std::sync::Arc<tokio::sync::Mutex<AttestationAgent>> =
+        std::sync::Arc::new(tokio::sync::Mutex::new(AttestationAgent::new()));
 }
 
 #[derive(Debug)]
@@ -85,17 +84,20 @@ struct KeyProviderKeyWrapProtocolOutput {
 }
 
 impl KeyProviderKeyWrapProtocolOutput {
+    #[cfg(feature = "keywrap-keyprovider-grpc")]
     async fn from_grpc(input: Vec<u8>, conn: &str, operation: OpKey) -> Result<Self> {
-        let uri = conn.parse::<Uri>().unwrap();
+        let uri = conn.parse::<tonic::codegen::http::Uri>().unwrap();
         // create a channel ie connection to server
         let channel = tonic::transport::Channel::builder(uri)
             .connect()
             .await
-            .map_err(|e| anyhow!("keyprovider: error while creating channel: {:?}", e))?;
+            .map_err(|e| anyhow!("keyprovider: error while creating channel: {e}"))?;
 
         let mut client =
-            keyproviderpb::key_provider_service_client::KeyProviderServiceClient::new(channel);
-        let msg = keyproviderpb::KeyProviderKeyWrapProtocolInput {
+            crate::utils::keyprovider::key_provider_service_client::KeyProviderServiceClient::new(
+                channel,
+            );
+        let msg = crate::utils::keyprovider::KeyProviderKeyWrapProtocolInput {
             key_provider_key_wrap_protocol_input: input,
         };
         let request = tonic::Request::new(msg);
@@ -124,28 +126,30 @@ impl KeyProviderKeyWrapProtocolOutput {
         )
         .map_err(|_| {
             anyhow!(
-                "Error while deserializing grpc output on {:?} operation",
-                OpKey::Unwrap.to_string()
+                "Error while deserializing grpc output on {} operation",
+                OpKey::Unwrap
             )
         })
     }
 
+    #[cfg(feature = "keywrap-keyprovider-cmd")]
     fn from_command(
         input: Vec<u8>,
-        command: &Command,
-        runner: &dyn utils::CommandExecuter,
+        command: &crate::config::Command,
+        runner: &dyn crate::utils::CommandExecuter,
     ) -> Result<Self> {
         let cmd_name = command.path.to_string();
         let default_args = vec![];
         let args = command.args.as_ref().unwrap_or(&default_args);
         let resp_bytes: Vec<u8> = runner
             .exec(cmd_name, args, input)
-            .map_err(|e| anyhow!("keyprovider: error from command executor: {:?}", e))?;
+            .map_err(|e| anyhow!("keyprovider: error from command executor: {}", e))?;
 
         serde_json::from_slice(&resp_bytes)
             .map_err(|_| anyhow!("keyprovider: failed to deserialize message from binary executor"))
     }
 
+    #[cfg(feature = "keywrap-keyprovider-native")]
     fn from_native(annotation: &str, dc_config: &DecryptConfig) -> Result<Self> {
         let kbc_kbs_pair = if let Some(list) = dc_config.param.get("attestation-agent") {
             list.get(0)
@@ -165,10 +169,10 @@ impl KeyProviderKeyWrapProtocolOutput {
             create_async_runtime()?.block_on(async {
                 ATTESTATION_AGENT
                     .lock()
-                    .unwrap()
+                    .await
                     .decrypt_image_layer_annotation(kbc, kbs, annotation)
                     .await
-                    .map_err(|e| format!("{}", e))
+                    .map_err(|e| format!("{e}"))
             })
         });
 
@@ -177,8 +181,8 @@ impl KeyProviderKeyWrapProtocolOutput {
                 key_unwrap_results: Some(KeyUnwrapResults { opts_data: v }),
                 ..Default::default()
             }),
-            Ok(Err(e)) => Err(anyhow!("keyprovider: retrieve opts_data failed: {}", e)),
-            Err(e) => Err(anyhow!("keyprovider: retrieve opts_data failed: {:?}", e)),
+            Ok(Err(e)) => Err(anyhow!("keyprovider: retrieve opts_data failed: {e}")),
+            Err(e) => Err(anyhow!("keyprovider: retrieve opts_data failed: {e:?}")),
         }
     }
 }
@@ -236,66 +240,89 @@ impl KeyWrapper for KeyProviderKeyWrapper {
             key_wrap_params,
             key_unwrap_params: KeyUnwrapParams::default(),
         };
-        let serialized_input = serde_json::to_vec(&input).map_err(|_| {
+        let _serialized_input = serde_json::to_vec(&input).map_err(|_| {
             anyhow!(
                 "keyprovider: error while serializing input parameters for {} operation",
                 OpKey::Wrap
             )
         })?;
 
-        let protocol_output = if let Some(cmd) = &self.attrs.cmd {
-            if let Some(runner) = self.runner.as_ref() {
-                KeyProviderKeyWrapProtocolOutput::from_command(serialized_input, cmd, runner)
+        if let Some(_cmd) = &self.attrs.cmd {
+            if let Some(_runner) = self.runner.as_ref() {
+                #[cfg(not(feature = "keywrap-keyprovider-cmd"))]
+                {
+                    Err(anyhow!("keyprovider: no support of keyprovider-grpc"))
+                }
+                #[cfg(feature = "keywrap-keyprovider-cmd")]
+                {
+                    let protocol_output = KeyProviderKeyWrapProtocolOutput::from_command(
+                        _serialized_input,
+                        _cmd,
+                        _runner,
+                    )
                     .map_err(|e| {
                         anyhow!(
-                            "keyprovider: error from binary provider for {} operation: {:?}",
+                            "keyprovider: error from binary provider for {} operation: {e}",
                             OpKey::Wrap,
-                            e
                         )
-                    })?
+                    })?;
+                    if let Some(result) = protocol_output.key_wrap_results {
+                        Ok(result.annotation)
+                    } else {
+                        Err(anyhow!("keyprovider: get NULL reply from provider"))
+                    }
+                }
             } else {
-                return Err(anyhow!("keyprovider: runner for binary provider is NULL"));
+                Err(anyhow!("keyprovider: runner for binary provider is NULL"))
             }
         } else if let Some(grpc) = self.attrs.grpc.as_ref() {
-            let grpc = grpc.to_string();
-            let handler = std::thread::spawn(move || {
-                create_async_runtime()?.block_on(async {
-                    KeyProviderKeyWrapProtocolOutput::from_grpc(
-                        serialized_input,
-                        &grpc,
-                        OpKey::Wrap,
-                    )
-                    .await
-                    .map_err(|e| format!("{}", e))
-                })
-            });
-            match handler.join() {
-                Ok(Ok(v)) => v,
-                Ok(Err(e)) => {
-                    return Err(anyhow!(
-                        "keyprovider: grpc provider failed to execute {} operation: {}",
-                        OpKey::Wrap,
-                        e
-                    ));
-                }
-                Err(e) => {
-                    return Err(anyhow!(
-                        "keyprovider: grpc provider failed to execute {} operation: {:?}",
-                        OpKey::Wrap,
-                        e
-                    ));
+            #[cfg(not(feature = "keywrap-keyprovider-grpc"))]
+            {
+                Err(anyhow!(
+                    "keyprovider: no support of keyprovider-grpc, {}",
+                    grpc
+                ))
+            }
+            #[cfg(feature = "keywrap-keyprovider-grpc")]
+            {
+                let grpc = grpc.to_string();
+                let handler = std::thread::spawn(move || {
+                    create_async_runtime()?.block_on(async {
+                        KeyProviderKeyWrapProtocolOutput::from_grpc(
+                            _serialized_input,
+                            &grpc,
+                            OpKey::Wrap,
+                        )
+                        .await
+                        .map_err(|e| format!("{e}"))
+                    })
+                });
+                let protocol_output = match handler.join() {
+                    Ok(Ok(v)) => v,
+                    Ok(Err(e)) => {
+                        return Err(anyhow!(
+                            "keyprovider: grpc provider failed to execute {} operation: {}",
+                            OpKey::Wrap,
+                            e
+                        ));
+                    }
+                    Err(e) => {
+                        return Err(anyhow!(
+                            "keyprovider: grpc provider failed to execute {} operation: {e:?}",
+                            OpKey::Wrap,
+                        ));
+                    }
+                };
+                if let Some(result) = protocol_output.key_wrap_results {
+                    Ok(result.annotation)
+                } else {
+                    Err(anyhow!("keyprovider: get NULL reply from provider"))
                 }
             }
         } else {
-            return Err(anyhow!(
+            Err(anyhow!(
                 "keyprovider: invalid configuration, both grpc and runner are NULL"
-            ));
-        };
-
-        if let Some(result) = protocol_output.key_wrap_results {
-            Ok(result.annotation)
-        } else {
-            Err(anyhow!("keyprovider: get NULL reply from provider"))
+            ))
         }
     }
 
@@ -314,69 +341,86 @@ impl KeyWrapper for KeyProviderKeyWrapper {
             key_wrap_params: KeyWrapParams::default(),
             key_unwrap_params,
         };
-        let serialized_input = serde_json::to_vec(&input).map_err(|_| {
+        let _serialized_input = serde_json::to_vec(&input).map_err(|_| {
             anyhow!(
                 "keyprovider: error while serializing input parameters for {} operation",
                 OpKey::Unwrap.to_string()
             )
         })?;
 
-        let protocol_output = if let Some(cmd) = self.attrs.cmd.as_ref() {
-            if let Some(runner) = self.runner.as_ref() {
-                KeyProviderKeyWrapProtocolOutput::from_command(serialized_input, cmd, runner)
-                    .map_err(|e| {
-                        anyhow!(
-                            "keyprovider: error from binary provider for {} operation: {:?}",
-                            OpKey::Unwrap.to_string(),
-                            e
-                        )
-                    })?
+        let _protocol_output: KeyProviderKeyWrapProtocolOutput = if let Some(_cmd) =
+            self.attrs.cmd.as_ref()
+        {
+            if let Some(_runner) = self.runner.as_ref() {
+                #[cfg(not(feature = "keywrap-keyprovider-cmd"))]
+                return Err(anyhow!("keyprovider: no support of keyprovider-grpc"));
+                #[cfg(feature = "keywrap-keyprovider-cmd")]
+                {
+                    KeyProviderKeyWrapProtocolOutput::from_command(_serialized_input, _cmd, _runner)
+                        .map_err(|e| {
+                            anyhow!(
+                                "keyprovider: error from binary provider for {} operation: {e}",
+                                OpKey::Unwrap.to_string(),
+                            )
+                        })?
+                }
             } else {
                 return Err(anyhow!("keyprovider: runner for binary provider is NULL"));
             }
         } else if let Some(grpc) = self.attrs.grpc.as_ref() {
-            let grpc = grpc.to_string();
-            let handler = std::thread::spawn(move || {
-                create_async_runtime()?.block_on(async {
-                    KeyProviderKeyWrapProtocolOutput::from_grpc(
-                        serialized_input,
-                        &grpc,
-                        OpKey::Unwrap,
-                    )
-                    .await
-                    .map_err(|e| {
-                        format!(
-                            "keyprovider: grpc provider failed to execute {} operation: {:?}",
-                            OpKey::Wrap,
-                            e
+            #[cfg(not(feature = "keywrap-keyprovider-grpc"))]
+            return Err(anyhow!(
+                "keyprovider: no support of keyprovider-grpc, {}",
+                grpc
+            ));
+            #[cfg(feature = "keywrap-keyprovider-grpc")]
+            {
+                let grpc = grpc.to_string();
+                let handler = std::thread::spawn(move || {
+                    create_async_runtime()?.block_on(async {
+                        KeyProviderKeyWrapProtocolOutput::from_grpc(
+                            _serialized_input,
+                            &grpc,
+                            OpKey::Unwrap,
                         )
+                        .await
+                        .map_err(|e| {
+                            format!(
+                                "keyprovider: grpc provider failed to execute {} operation: {e}",
+                                OpKey::Wrap,
+                            )
+                        })
                     })
-                })
-            });
-            match handler.join() {
-                Ok(Ok(v)) => v,
-                Ok(Err(e)) => return Err(anyhow!("failed to unwrap key by gRPC, {}", e)),
-                Err(e) => return Err(anyhow!("failed to unwrap key by gRPC, {:?}", e)),
+                });
+                match handler.join() {
+                    Ok(Ok(v)) => v,
+                    Ok(Err(e)) => return Err(anyhow!("failed to unwrap key by gRPC, {e}")),
+                    Err(e) => return Err(anyhow!("failed to unwrap key by gRPC, {e:?}")),
+                }
             }
         } else if let Some(_native) = self.attrs.native.as_ref() {
-            KeyProviderKeyWrapProtocolOutput::from_native(
-                &String::from_utf8(json_string.to_vec())?,
-                dc_config,
-            )
-            .map_err(|e| {
-                anyhow!(
-                    "keyprovider: error from crate provider for {} operation: {:?}",
-                    OpKey::Unwrap.to_string(),
-                    e
+            #[cfg(not(feature = "keywrap-keyprovider-native"))]
+            return Err(anyhow!("keyprovider: no support of keyprovider-native"));
+            #[cfg(feature = "keywrap-keyprovider-native")]
+            {
+                KeyProviderKeyWrapProtocolOutput::from_native(
+                    &String::from_utf8(json_string.to_vec())?,
+                    dc_config,
                 )
-            })?
+                .map_err(|e| {
+                    anyhow!(
+                        "keyprovider: error from crate provider for {} operation: {e}",
+                        OpKey::Unwrap.to_string(),
+                    )
+                })?
+            }
         } else {
             return Err(anyhow!(
                 "keyprovider: invalid configuration, both grpc and runner are NULL"
             ));
         };
 
-        if let Some(result) = protocol_output.key_unwrap_results {
+        if let Some(result) = _protocol_output.key_unwrap_results {
             Ok(result.opts_data)
         } else {
             Err(anyhow!("keyprovider: get NULL reply from provider"))
@@ -395,57 +439,33 @@ impl KeyWrapper for KeyProviderKeyWrapper {
     }
 }
 
-fn create_async_runtime() -> std::result::Result<Runtime, String> {
-    match Builder::new_current_thread().enable_io().build() {
-        Err(e) => Err(format!(
-            "keyprovider: failed to create async runtime, {}",
-            e
-        )),
+#[cfg(any(
+    feature = "keywrap-keyprovider-grpc",
+    feature = "keywrap-keyprovider-native"
+))]
+fn create_async_runtime() -> std::result::Result<tokio::runtime::Runtime, String> {
+    match tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+    {
+        Err(e) => Err(format!("keyprovider: failed to create async runtime, {e}")),
         Ok(rt) => Ok(rt),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::config;
-    use crate::config::{DecryptConfig, EncryptConfig};
+    use super::*;
+    #[cfg(feature = "keywrap-keyprovider-native")]
     use crate::helpers::create_decrypt_config;
-    use crate::keywrap::keyprovider::{
-        KeyProviderKeyWrapProtocolInput, KeyProviderKeyWrapProtocolOutput, KeyProviderKeyWrapper,
-        KeyUnwrapResults, KeyWrapResults,
-    };
-    use crate::keywrap::{keyprovider, KeyWrapper};
-    use crate::utils::keyprovider::key_provider_service_server::KeyProviderService;
-    use crate::utils::keyprovider::key_provider_service_server::KeyProviderServiceServer;
-    use crate::utils::keyprovider::{
-        KeyProviderKeyWrapProtocolInput as grpc_input,
-        KeyProviderKeyWrapProtocolOutput as grpc_output,
-    };
-    use crate::utils::CommandExecuter;
-    use aes_gcm::aead::{Aead, NewAead};
-    use aes_gcm::{Aes256Gcm, Key, Nonce};
-    use anyhow::{anyhow, Result};
-    use std::collections::HashMap;
-    use std::fs;
-    use std::io::{Error, ErrorKind};
-    use std::net::SocketAddr;
-    use std::thread::sleep;
-    use std::time::Duration;
-    use tokio::runtime::Runtime;
-    use tokio::sync::mpsc;
-    use tonic;
-    use tonic::{transport::Server, Request};
 
     ///Test runner which mocks binary executable for key wrapping and unwrapping
     #[derive(Clone, Copy)]
     pub struct TestRunner {}
 
-    static mut ENC_KEY: &[u8; 32] = b"passphrasewhichneedstobe32bytes!";
-    static mut DEC_KEY: &[u8; 32] = b"passphrasewhichneedstobe32bytes!";
-
     ///Mock annotation packet, which goes into container image manifest
     #[derive(Serialize, Deserialize, Debug)]
-    pub struct AnnotationPacket {
+    struct AnnotationPacket {
         pub key_url: String,
         pub wrapped_key: Vec<u8>,
         pub wrap_type: String,
@@ -455,150 +475,220 @@ mod tests {
     #[derive(Default)]
     struct TestServer {}
 
-    pub fn encrypt_key(plain_text: &[u8], encrypting_key: &[u8; 32]) -> Result<Vec<u8>> {
-        let encrypting_key = Key::from_slice(encrypting_key);
-        let cipher = Aes256Gcm::new(encrypting_key);
-        let nonce = Nonce::from_slice(b"unique nonce");
+    #[cfg(any(
+        feature = "keywrap-keyprovider-cmd",
+        feature = "keywrap-keyprovider-grpc"
+    ))]
+    mod cmd_grpc {
+        use aes_gcm::aead::{Aead, NewAead};
+        use aes_gcm::{Aes256Gcm, Key, Nonce};
+        use anyhow::{anyhow, Result};
 
-        cipher
-            .encrypt(nonce, plain_text.as_ref())
-            .map_err(|_| anyhow!("encryption failure"))
-    }
+        pub static mut ENC_KEY: &[u8; 32] = b"passphrasewhichneedstobe32bytes!";
+        pub static mut DEC_KEY: &[u8; 32] = b"passphrasewhichneedstobe32bytes!";
 
-    pub fn decrypt_key(cipher_text: &[u8], decrypting_key: &[u8; 32]) -> Result<Vec<u8>> {
-        let decrypting_key = Key::from_slice(decrypting_key);
-        let cipher = Aes256Gcm::new(decrypting_key);
-        let nonce = Nonce::from_slice(b"unique nonce");
+        pub fn encrypt_key(plain_text: &[u8], encrypting_key: &[u8; 32]) -> Result<Vec<u8>> {
+            let encrypting_key = Key::from_slice(encrypting_key);
+            let cipher = Aes256Gcm::new(encrypting_key);
+            let nonce = Nonce::from_slice(b"unique nonce");
 
-        cipher
-            .decrypt(nonce, cipher_text.as_ref())
-            .map_err(|_| anyhow!("decryption failure"))
-    }
-
-    #[tonic::async_trait]
-    impl KeyProviderService for TestServer {
-        async fn wrap_key(
-            &self,
-            request: Request<grpc_input>,
-        ) -> core::result::Result<tonic::Response<grpc_output>, tonic::Status> {
-            let key_wrap_input: keyprovider::KeyProviderKeyWrapProtocolInput =
-                serde_json::from_slice(&request.into_inner().key_provider_key_wrap_protocol_input)
-                    .unwrap();
-            let plain_optsdata = key_wrap_input.key_wrap_params.opts_data.unwrap();
-            if let Ok(wrapped_key_result) =
-                encrypt_key(&base64::decode(plain_optsdata).unwrap(), unsafe { ENC_KEY })
-            {
-                let ap = AnnotationPacket {
-                    key_url: "https://key-provider/key-uuid".to_string(),
-                    wrapped_key: wrapped_key_result,
-                    wrap_type: "AES".to_string(),
-                };
-                let serialized_ap = serde_json::to_vec(&ap).unwrap();
-                let key_wrap_output = KeyProviderKeyWrapProtocolOutput {
-                    key_wrap_results: Some(KeyWrapResults {
-                        annotation: serialized_ap,
-                    }),
-                    key_unwrap_results: None,
-                };
-                let serialized_key_wrap_output = serde_json::to_vec(&key_wrap_output).unwrap();
-
-                Ok(tonic::Response::new(grpc_output {
-                    key_provider_key_wrap_protocol_output: serialized_key_wrap_output,
-                }))
-            } else {
-                Err(tonic::Status::unknown("Error while encrypting key"))
-            }
+            cipher
+                .encrypt(nonce, plain_text.as_ref())
+                .map_err(|_| anyhow!("encryption failure"))
         }
 
-        async fn un_wrap_key(
-            &self,
-            request: Request<grpc_input>,
-        ) -> core::result::Result<tonic::Response<grpc_output>, tonic::Status> {
-            let key_wrap_input: keyprovider::KeyProviderKeyWrapProtocolInput =
-                serde_json::from_slice(&request.into_inner().key_provider_key_wrap_protocol_input)
-                    .unwrap();
-            let base64_annotation = key_wrap_input.key_unwrap_params.annotation.unwrap();
-            let vec_annotation = base64::decode(base64_annotation).unwrap();
-            let str_annotation: &str = std::str::from_utf8(&vec_annotation).unwrap();
-            let annotation_packet: AnnotationPacket = serde_json::from_str(str_annotation).unwrap();
-            let wrapped_key = annotation_packet.wrapped_key;
-            if let Ok(unwrapped_key_result) = decrypt_key(&wrapped_key, unsafe { DEC_KEY }) {
-                let key_wrap_output = KeyProviderKeyWrapProtocolOutput {
-                    key_wrap_results: None,
-                    key_unwrap_results: Some(KeyUnwrapResults {
-                        opts_data: unwrapped_key_result,
-                    }),
-                };
-                let serialized_key_wrap_output = serde_json::to_vec(&key_wrap_output).unwrap();
-                Ok(tonic::Response::new(grpc_output {
-                    key_provider_key_wrap_protocol_output: serialized_key_wrap_output,
-                }))
-            } else {
-                Err(tonic::Status::unknown("Error while decrypting key"))
-            }
+        pub fn decrypt_key(cipher_text: &[u8], decrypting_key: &[u8; 32]) -> Result<Vec<u8>> {
+            let decrypting_key = Key::from_slice(decrypting_key);
+            let cipher = Aes256Gcm::new(decrypting_key);
+            let nonce = Nonce::from_slice(b"unique nonce");
+
+            cipher
+                .decrypt(nonce, cipher_text.as_ref())
+                .map_err(|_| anyhow!("decryption failure"))
         }
     }
 
-    impl CommandExecuter for TestRunner {
-        /// Mock CommandExecuter for executing a linux command line command and return the output of the command with an error if it exists.
-        fn exec(
-            &self,
-            cmd: String,
-            _args: &[std::string::String],
-            input: Vec<u8>,
-        ) -> Result<Vec<u8>> {
-            let mut key_wrap_output = KeyProviderKeyWrapProtocolOutput::default();
-            if cmd == "/usr/lib/keyprovider-wrapkey" {
-                let key_wrap_input: KeyProviderKeyWrapProtocolInput =
-                    serde_json::from_slice(input.as_ref()).unwrap();
+    #[cfg(feature = "keywrap-keyprovider-grpc")]
+    mod grpc {
+        use super::cmd_grpc::{decrypt_key, encrypt_key, DEC_KEY, ENC_KEY};
+        use super::*;
+        use crate::utils::keyprovider::key_provider_service_server::KeyProviderService;
+        use crate::utils::keyprovider::key_provider_service_server::KeyProviderServiceServer;
+        use crate::utils::keyprovider::{
+            KeyProviderKeyWrapProtocolInput as grpc_input,
+            KeyProviderKeyWrapProtocolOutput as grpc_output,
+        };
+        use std::net::SocketAddr;
+        use tokio::sync::mpsc;
+        use tonic;
+        use tonic::{transport::Server, Request};
+
+        #[tonic::async_trait]
+        impl KeyProviderService for TestServer {
+            async fn wrap_key(
+                &self,
+                request: Request<grpc_input>,
+            ) -> core::result::Result<tonic::Response<grpc_output>, tonic::Status> {
+                let key_wrap_input: super::super::KeyProviderKeyWrapProtocolInput =
+                    serde_json::from_slice(
+                        &request.into_inner().key_provider_key_wrap_protocol_input,
+                    )
+                    .unwrap();
                 let plain_optsdata = key_wrap_input.key_wrap_params.opts_data.unwrap();
-                let wrapped_key =
+                if let Ok(wrapped_key_result) =
                     encrypt_key(&base64::decode(plain_optsdata).unwrap(), unsafe { ENC_KEY })
-                        .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
-                let ap = AnnotationPacket {
-                    key_url: "https://key-provider/key-uuid".to_string(),
-                    wrapped_key,
-                    wrap_type: "AES".to_string(),
-                };
-                let serialized_ap = serde_json::to_vec(&ap).unwrap();
-                key_wrap_output = KeyProviderKeyWrapProtocolOutput {
-                    key_wrap_results: Some(KeyWrapResults {
-                        annotation: serialized_ap,
-                    }),
-                    key_unwrap_results: None,
-                };
-            } else if cmd == "/usr/lib/keyprovider-unwrapkey" {
-                let key_wrap_input: KeyProviderKeyWrapProtocolInput =
-                    serde_json::from_slice(input.as_ref()).unwrap();
+                {
+                    let ap = AnnotationPacket {
+                        key_url: "https://key-provider/key-uuid".to_string(),
+                        wrapped_key: wrapped_key_result,
+                        wrap_type: "AES".to_string(),
+                    };
+                    let serialized_ap = serde_json::to_vec(&ap).unwrap();
+                    let key_wrap_output = super::super::KeyProviderKeyWrapProtocolOutput {
+                        key_wrap_results: Some(super::super::KeyWrapResults {
+                            annotation: serialized_ap,
+                        }),
+                        key_unwrap_results: None,
+                    };
+                    let serialized_key_wrap_output = serde_json::to_vec(&key_wrap_output).unwrap();
+
+                    Ok(tonic::Response::new(grpc_output {
+                        key_provider_key_wrap_protocol_output: serialized_key_wrap_output,
+                    }))
+                } else {
+                    Err(tonic::Status::unknown("Error while encrypting key"))
+                }
+            }
+
+            async fn un_wrap_key(
+                &self,
+                request: Request<grpc_input>,
+            ) -> core::result::Result<tonic::Response<grpc_output>, tonic::Status> {
+                let key_wrap_input: super::super::KeyProviderKeyWrapProtocolInput =
+                    serde_json::from_slice(
+                        &request.into_inner().key_provider_key_wrap_protocol_input,
+                    )
+                    .unwrap();
                 let base64_annotation = key_wrap_input.key_unwrap_params.annotation.unwrap();
                 let vec_annotation = base64::decode(base64_annotation).unwrap();
                 let str_annotation: &str = std::str::from_utf8(&vec_annotation).unwrap();
                 let annotation_packet: AnnotationPacket =
                     serde_json::from_str(str_annotation).unwrap();
                 let wrapped_key = annotation_packet.wrapped_key;
-                let unwrapped_key = decrypt_key(&wrapped_key, unsafe { DEC_KEY })
-                    .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
-                key_wrap_output = KeyProviderKeyWrapProtocolOutput {
-                    key_wrap_results: None,
-                    key_unwrap_results: Some(KeyUnwrapResults {
-                        opts_data: unwrapped_key,
-                    }),
-                };
+                if let Ok(unwrapped_key_result) = decrypt_key(&wrapped_key, unsafe { DEC_KEY }) {
+                    let key_wrap_output = super::super::KeyProviderKeyWrapProtocolOutput {
+                        key_wrap_results: None,
+                        key_unwrap_results: Some(super::super::KeyUnwrapResults {
+                            opts_data: unwrapped_key_result,
+                        }),
+                    };
+                    let serialized_key_wrap_output = serde_json::to_vec(&key_wrap_output).unwrap();
+                    Ok(tonic::Response::new(grpc_output {
+                        key_provider_key_wrap_protocol_output: serialized_key_wrap_output,
+                    }))
+                } else {
+                    Err(tonic::Status::unknown("Error while decrypting key"))
+                }
             }
-            let serialized_keywrap_output = serde_json::to_vec(&key_wrap_output).unwrap();
+        }
 
-            Ok(serialized_keywrap_output)
+        // Function to start a mock grpc server
+        pub fn start_grpc_server(sock_address: String) {
+            tokio::spawn(async move {
+                let (tx, mut rx) = mpsc::unbounded_channel();
+                let addr: SocketAddr = sock_address.parse().unwrap();
+                let server = TestServer::default();
+                let serve = Server::builder()
+                    .add_service(KeyProviderServiceServer::new(server))
+                    .serve(addr);
+
+                tokio::spawn(async move {
+                    if let Err(e) = serve.await {
+                        eprintln!("Error = {e}");
+                    }
+
+                    tx.send(()).unwrap();
+                });
+
+                rx.recv().await;
+            });
         }
     }
 
+    #[cfg(feature = "keywrap-keyprovider-cmd")]
+    mod cmd {
+        use super::super::{
+            KeyProviderKeyWrapProtocolInput, KeyProviderKeyWrapProtocolOutput, KeyUnwrapResults,
+            KeyWrapResults,
+        };
+        use super::*;
+
+        impl crate::utils::CommandExecuter for TestRunner {
+            /// Mock CommandExecuter for executing a linux command line command and return the output of the command with an error if it exists.
+            fn exec(
+                &self,
+                cmd: String,
+                _args: &[std::string::String],
+                input: Vec<u8>,
+            ) -> anyhow::Result<Vec<u8>> {
+                let mut key_wrap_output = KeyProviderKeyWrapProtocolOutput::default();
+                if cmd == "/usr/lib/keyprovider-wrapkey" {
+                    let key_wrap_input: KeyProviderKeyWrapProtocolInput =
+                        serde_json::from_slice(input.as_ref()).unwrap();
+                    let plain_optsdata = key_wrap_input.key_wrap_params.opts_data.unwrap();
+                    let wrapped_key = self::cmd_grpc::encrypt_key(
+                        &base64::decode(plain_optsdata).unwrap(),
+                        unsafe { self::cmd_grpc::ENC_KEY },
+                    )
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+                    let ap = AnnotationPacket {
+                        key_url: "https://key-provider/key-uuid".to_string(),
+                        wrapped_key,
+                        wrap_type: "AES".to_string(),
+                    };
+                    let serialized_ap = serde_json::to_vec(&ap).unwrap();
+                    key_wrap_output = KeyProviderKeyWrapProtocolOutput {
+                        key_wrap_results: Some(KeyWrapResults {
+                            annotation: serialized_ap,
+                        }),
+                        key_unwrap_results: None,
+                    };
+                } else if cmd == "/usr/lib/keyprovider-unwrapkey" {
+                    let key_wrap_input: KeyProviderKeyWrapProtocolInput =
+                        serde_json::from_slice(input.as_ref()).unwrap();
+                    let base64_annotation = key_wrap_input.key_unwrap_params.annotation.unwrap();
+                    let vec_annotation = base64::decode(base64_annotation).unwrap();
+                    let str_annotation: &str = std::str::from_utf8(&vec_annotation).unwrap();
+                    let annotation_packet: AnnotationPacket =
+                        serde_json::from_str(str_annotation).unwrap();
+                    let wrapped_key = annotation_packet.wrapped_key;
+                    let unwrapped_key = super::cmd_grpc::decrypt_key(&wrapped_key, unsafe {
+                        super::cmd_grpc::DEC_KEY
+                    })
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+                    key_wrap_output = KeyProviderKeyWrapProtocolOutput {
+                        key_wrap_results: None,
+                        key_unwrap_results: Some(KeyUnwrapResults {
+                            opts_data: unwrapped_key,
+                        }),
+                    };
+                }
+                let serialized_keywrap_output = serde_json::to_vec(&key_wrap_output).unwrap();
+
+                Ok(serialized_keywrap_output)
+            }
+        }
+    }
+
+    #[cfg(feature = "keywrap-keyprovider-cmd")]
     #[test]
     #[ignore]
     fn test_key_provider_command_success() {
         let test_runner = TestRunner {};
-        let mut provider = HashMap::new();
+        let mut provider = std::collections::HashMap::new();
         let mut dc_params = vec![];
-        let mut attrs = config::KeyProviderAttrs {
-            cmd: Some(config::Command {
+        let mut attrs = crate::config::KeyProviderAttrs {
+            cmd: Some(crate::config::Command {
                 path: "/usr/lib/keyprovider-wrapkey".to_string(),
                 args: None,
             }),
@@ -613,15 +703,15 @@ mod tests {
         );
 
         unsafe {
-            ENC_KEY = b"passphrasewhichneedstobe32bytes!";
-            DEC_KEY = b"passphrasewhichneedstobe32bytes!";
+            self::cmd_grpc::ENC_KEY = b"passphrasewhichneedstobe32bytes!";
+            self::cmd_grpc::DEC_KEY = b"passphrasewhichneedstobe32bytes!";
         }
 
         // Prepare for mock encryption config
         let opts_data = b"symmetric_key";
         let b64_opts_data = base64::encode(opts_data).into_bytes();
-        let mut ec = EncryptConfig::default();
-        let mut dc = DecryptConfig::default();
+        let mut ec = crate::keywrap::EncryptConfig::default();
+        let mut dc = crate::keywrap::DecryptConfig::default();
         let mut ec_params = vec![];
         let param = "keyprovider".to_string().into_bytes();
         ec_params.push(param.clone());
@@ -634,8 +724,8 @@ mod tests {
         let key_wrap_output_result = keyprovider_key_wrapper.wrap_keys(&ec, &b64_opts_data);
 
         // Create keyprovider-key-wrapper
-        attrs = config::KeyProviderAttrs {
-            cmd: Some(config::Command {
+        attrs = crate::config::KeyProviderAttrs {
+            cmd: Some(crate::config::Command {
                 path: "/usr/lib/keyprovider-unwrapkey".to_string(),
                 args: None,
             }),
@@ -658,13 +748,14 @@ mod tests {
         assert_eq!(opts_data.to_vec(), unwrapped_key);
     }
 
+    #[cfg(feature = "keywrap-keyprovider-cmd")]
     #[test]
     fn test_command_executer_wrap_key_fail() {
         let test_runner = TestRunner {};
         let mut ec_params = vec![];
-        let mut provider = HashMap::new();
-        let attrs = config::KeyProviderAttrs {
-            cmd: Some(config::Command {
+        let mut provider = std::collections::HashMap::new();
+        let attrs = crate::config::KeyProviderAttrs {
+            cmd: Some(crate::config::Command {
                 path: "/usr/lib/keyprovider-wrapkey".to_string(),
                 args: None,
             }),
@@ -679,7 +770,7 @@ mod tests {
         );
 
         let b64_opts_data = base64::encode(b"symmetric_key").into_bytes();
-        let mut ec = EncryptConfig::default();
+        let mut ec = crate::keywrap::EncryptConfig::default();
         ec_params.push("keyprovider1".to_string().into_bytes());
         assert!(ec.encrypt_with_key_provider(ec_params).is_ok());
         assert!(keyprovider_key_wrapper
@@ -687,14 +778,15 @@ mod tests {
             .is_err());
     }
 
+    #[cfg(feature = "keywrap-keyprovider-cmd")]
     #[test]
     fn test_command_executer_unwrap_key_fail() {
         let test_runner = TestRunner {};
         let mut dc_params = vec![];
 
-        let mut provider = HashMap::new();
-        let attrs = config::KeyProviderAttrs {
-            cmd: Some(config::Command {
+        let mut provider = std::collections::HashMap::new();
+        let attrs = crate::config::KeyProviderAttrs {
+            cmd: Some(crate::config::Command {
                 path: "/usr/lib/keyprovider-unwrapkey".to_string(),
                 args: None,
             }),
@@ -710,7 +802,9 @@ mod tests {
 
         // Perform manual encryption
         let opts_data = b"symmetric_key";
-        let wrapped_key = encrypt_key(opts_data.as_ref(), unsafe { ENC_KEY }).unwrap();
+        let wrapped_key =
+            self::cmd_grpc::encrypt_key(opts_data.as_ref(), unsafe { self::cmd_grpc::ENC_KEY })
+                .unwrap();
         let ap = AnnotationPacket {
             key_url: "https://key-provider/key-uuid".to_string(),
             wrapped_key,
@@ -719,54 +813,33 @@ mod tests {
         let serialized_ap = serde_json::to_vec(&ap).unwrap();
 
         // Change the decryption key so that decryption should fail
-        unsafe { DEC_KEY = b"wrong_passwhichneedstobe32bytes!" };
+        unsafe { self::cmd_grpc::DEC_KEY = b"wrong_passwhichneedstobe32bytes!" };
 
         // Prepare for mock decryption config
         dc_params.push("keyprovider1".to_string().as_bytes().to_vec());
-        let mut dc = DecryptConfig::default();
+        let mut dc = crate::keywrap::DecryptConfig::default();
         assert!(dc.decrypt_with_key_provider(dc_params).is_ok());
         assert!(keyprovider_key_wrapper
             .unwrap_keys(&dc, &serialized_ap)
             .is_err());
     }
 
-    // Function to start a mock grpc server
-    fn start_grpc_server(sock_address: String) {
-        tokio::spawn(async move {
-            let (tx, mut rx) = mpsc::unbounded_channel();
-            let addr: SocketAddr = sock_address.parse().unwrap();
-            let server = TestServer::default();
-            let serve = Server::builder()
-                .add_service(KeyProviderServiceServer::new(server))
-                .serve(addr);
-
-            tokio::spawn(async move {
-                if let Err(e) = serve.await {
-                    eprintln!("Error = {e:?}");
-                }
-
-                tx.send(()).unwrap();
-            });
-
-            rx.recv().await;
-        });
-    }
-
+    #[cfg(feature = "keywrap-keyprovider-grpc")]
     #[test]
     fn test_key_provider_grpc_tcp_success() {
-        let rt = Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         let _guard = rt.enter();
-        start_grpc_server("127.0.0.1:8990".to_string());
+        self::grpc::start_grpc_server("127.0.0.1:8990".to_string());
         // sleep for few seconds so that grpc server bootstraps
-        sleep(Duration::from_secs(1));
+        std::thread::sleep(std::time::Duration::from_secs(1));
         unsafe {
-            ENC_KEY = b"passphrasewhichneedstobe32bytes!";
-            DEC_KEY = b"passphrasewhichneedstobe32bytes!";
+            self::cmd_grpc::ENC_KEY = b"passphrasewhichneedstobe32bytes!";
+            self::cmd_grpc::DEC_KEY = b"passphrasewhichneedstobe32bytes!";
         }
 
-        let mut provider = HashMap::new();
+        let mut provider = std::collections::HashMap::new();
         let mut dc_params = vec![];
-        let attrs = config::KeyProviderAttrs {
+        let attrs = crate::config::KeyProviderAttrs {
             cmd: None,
             grpc: Some("tcp://127.0.0.1:8990".to_string()),
             native: None,
@@ -778,8 +851,8 @@ mod tests {
         // Prepare encryption config params
         let opts_data = b"symmetric_key";
         let b64_opts_data = base64::encode(opts_data).into_bytes();
-        let mut ec = EncryptConfig::default();
-        let mut dc = DecryptConfig::default();
+        let mut ec = crate::keywrap::EncryptConfig::default();
+        let mut dc = crate::keywrap::DecryptConfig::default();
         let mut ec_params = vec![];
         let param = "keyprovider".to_string().into_bytes();
         ec_params.push(param.clone());
@@ -799,21 +872,22 @@ mod tests {
         rt.shutdown_background();
     }
 
+    #[cfg(feature = "keywrap-keyprovider-grpc")]
     #[test]
     fn test_key_provider_grpc_http_success() {
-        let rt = Runtime::new().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
         let _guard = rt.enter();
-        start_grpc_server("127.0.0.1:8991".to_string());
+        self::grpc::start_grpc_server("127.0.0.1:8991".to_string());
         // sleep for few seconds so that grpc server bootstraps
-        sleep(Duration::from_secs(1));
+        std::thread::sleep(std::time::Duration::from_secs(1));
         unsafe {
-            ENC_KEY = b"passphrasewhichneedstobe32bytes!";
-            DEC_KEY = b"passphrasewhichneedstobe32bytes!";
+            self::cmd_grpc::ENC_KEY = b"passphrasewhichneedstobe32bytes!";
+            self::cmd_grpc::DEC_KEY = b"passphrasewhichneedstobe32bytes!";
         }
 
-        let mut provider = HashMap::new();
+        let mut provider = std::collections::HashMap::new();
         let mut dc_params = vec![];
-        let attrs = config::KeyProviderAttrs {
+        let attrs = crate::config::KeyProviderAttrs {
             cmd: None,
             grpc: Some("http://127.0.0.1:8991".to_string()),
             native: None,
@@ -825,8 +899,8 @@ mod tests {
         // Prepare encryption config params
         let opts_data = b"symmetric_key";
         let b64_opts_data = base64::encode(opts_data).into_bytes();
-        let mut ec = EncryptConfig::default();
-        let mut dc = DecryptConfig::default();
+        let mut ec = crate::keywrap::EncryptConfig::default();
+        let mut dc = crate::keywrap::DecryptConfig::default();
         let mut ec_params = vec![];
         let param = "keyprovider".to_string().into_bytes();
         ec_params.push(param.clone());
@@ -847,11 +921,12 @@ mod tests {
         rt.shutdown_background();
     }
 
+    #[cfg(feature = "keywrap-keyprovider-native")]
     #[test]
     fn test_key_provider_native_fail() {
         let dummy_annotation: &str = "{}";
-        let mut provider = HashMap::new();
-        let attrs = config::KeyProviderAttrs {
+        let mut provider = std::collections::HashMap::new();
+        let attrs = crate::config::KeyProviderAttrs {
             cmd: None,
             grpc: None,
             native: Some("attestation-agent".to_string()),
@@ -881,10 +956,11 @@ mod tests {
         assert!(invalid_pair_msg.contains("keyprovider: invalid kbc::kbs pair"));
     }
 
+    #[cfg(feature = "keywrap-keyprovider-native")]
     #[test]
     fn test_key_provider_native_succuss() {
         let annotation_from_sample_kbc: Vec<u8> = {
-            let res = fs::read("data/sample_kbc_annotation.json");
+            let res = std::fs::read("data/sample_kbc_annotation.json");
             if let Ok(out) = res {
                 out
             } else {
@@ -892,8 +968,8 @@ mod tests {
             }
         };
 
-        let mut provider = HashMap::new();
-        let attrs = config::KeyProviderAttrs {
+        let mut provider = std::collections::HashMap::new();
+        let attrs = crate::config::KeyProviderAttrs {
             cmd: None,
             grpc: None,
             native: Some("attestation-agent".to_string()),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,16 +5,15 @@ use std::fmt::Debug;
 
 use anyhow::Result;
 
-#[cfg(feature = "utils-runner")]
+#[cfg(feature = "keywrap-keyprovider-cmd")]
 pub mod runner;
 
-#[cfg(feature = "utils-keyprovider")]
+#[cfg(feature = "keywrap-keyprovider-grpc")]
 #[rustfmt::skip]
 pub mod keyprovider;
 
 /// CommandExecuter trait which requires implementation for command exec, first argument is the command name, like /usr/bin/<command-name>,
 /// the second is the list of args to pass to it
-#[allow(unused_variables)]
 pub trait CommandExecuter: Send + Sync {
     fn exec(&self, cmd: String, args: &[String], input: Vec<u8>) -> Result<Vec<u8>>;
 }


### PR DESCRIPTION
The ocicrypt crate has heavy dependency, total 294 crates are compiled by default. So reduce the dependency by:
1) get rid of dependency on oci-distribute
2) add new features "keywrap-keyprovider-cmd/grpc/native" to control key-providers.

    Now we have:
    - cargo build --no-default-features: 66 crates
    - cargo build --no-default-features --features=keywrap-jwe: 91 crates
    - cargo build --no-default-features --features=keywrap-keyprovider-cmd: 66 crates
    - cargo build --no-default-features --features=keywrap-keyprovider-grpc: 166 crates
    - cargo build --no-default-features --features=keywrap-keyprovider-native: 217 crates
    - cargo build --all-features: 263 crates
