### PR TITLE
fix: Add Send trait constraint for async_decrypt_layer

### DIFF
--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -281,11 +281,11 @@ pub fn decrypt_layer<R: Read>(
 ///
 /// priv_opts_data can get from [`decrypt_layer_key_opts_data`]
 #[cfg(feature = "async-io")]
-pub fn async_decrypt_layer<R: tokio::io::AsyncRead>(
+pub fn async_decrypt_layer<R: tokio::io::AsyncRead + Send>(
     layer_reader: R,
     annotations: Option<&HashMap<String, String>>,
     priv_opts_data: &[u8],
-) -> Result<(impl tokio::io::AsyncRead, String)> {
+) -> Result<(impl tokio::io::AsyncRead + Send, String)> {
     let annotations = annotations.unwrap_or(&DEFAULT_ANNOTATION_MAP);
     let pub_opts_data = get_layer_pub_opts(annotations)?;
     let pub_opts: PublicLayerBlockCipherOptions = serde_json::from_slice(&pub_opts_data)?;

--- a/src/keywrap/keyprovider.rs
+++ b/src/keywrap/keyprovider.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use serde::Serialize;
 
 use crate::config::{DecryptConfig, EncryptConfig, KeyProviderAttrs};
@@ -303,7 +303,7 @@ impl KeyProviderKeyWrapper {
                 })
             }
         } else {
-            return Err(anyhow!("keyprovider: runner for binary provider is NULL"));
+            bail!("keyprovider: runner for binary provider is NULL");
         }
     }
 
@@ -334,8 +334,8 @@ impl KeyProviderKeyWrapper {
             });
             match handler.join() {
                 Ok(Ok(v)) => Ok(v),
-                Ok(Err(e)) => return Err(anyhow!("failed to unwrap key by gRPC, {e}")),
-                Err(e) => return Err(anyhow!("failed to unwrap key by gRPC, {e:?}")),
+                Ok(Err(e)) => bail!("failed to unwrap key by gRPC, {e}"),
+                Err(e) => bail!("failed to unwrap key by gRPC, {e:?}"),
             }
         }
     }


### PR DESCRIPTION
This trait constraint is needed when the caller of this function wants to transfer it between threads safely

Related error occurs upon the newest image-rs code when bring in async like https://github.com/confidential-containers/image-rs/pull/108