### PR TITLE
chore: update attestation-agent dep version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sha2 = { version = ">=0.10", optional = true }
 tokio = { version = "1.17.0", features = ["rt-multi-thread"], optional = true }
 tonic = { version = ">=0.8.0", optional = true }
 ttrpc = { version = "0.7.1", features = ["async"], default-features = false, optional = true }
-attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent", rev = "280c805", optional = true  }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent", rev = "95e4ade", optional = true  }
 
 [build-dependencies]
 tonic-build = {version = "0.8.0", optional = true }


### PR DESCRIPTION
last version of aa fixed a significant bug for connecting to kbs