### PR TITLE
chore: update aa version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sha2 = { version = ">=0.10", optional = true }
 tokio = { version = "1.17.0", features = ["rt-multi-thread"], optional = true }
 tonic = { version = ">=0.8.0", optional = true }
 ttrpc = { version = "0.7.1", features = ["async"], default-features = false, optional = true }
-attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", rev = "23874ca", optional = true  }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", rev = "542ee9b", optional = true  }
 
 [build-dependencies]
 tonic-build = {version = "0.8.0", optional = true }


### PR DESCRIPTION
Update version of AA

- AA now supports async ttrpc server


P.S. Hope this is the last version to update before v0.5.0