### PR TITLE
[DO NOT MERGE] chore: bump attestation-agent version with the latest one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sha2 = { version = ">=0.10", optional = true }
 tokio = { version = "1.17.0", features = ["rt-multi-thread"], optional = true }
 tonic = { version = ">=0.8.0", optional = true }
 ttrpc = { version = "0.7.1", features = ["async"], default-features = false, optional = true }
-attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", rev = "d7ace56", optional = true  }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", rev = "c939d21", optional = true  }
 
 [build-dependencies]
 tonic-build = {version = "0.8.0", optional = true }


### PR DESCRIPTION
This bump will fix the version of v0.5.0 release of attestation-agent version.

@wainersm Hi, please try to use this ocicrypt-rs from my fork in your image-rs to continue 1 on the checklist https://github.com/confidential-containers/community/issues/80 . The reason is we forget to sync the version of attestation-agent inside ocicrypt-rs. If the tests are ok, let's merge this PR