### PR TITLE
Cargo.toml: added new feature `cc_kbc_occlum`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Install tonic's protoc dependencies
         run: |
           apt install -y protobuf-compiler libprotobuf-dev
+
       - name: Build and install rats-tls
         run: | 
           apt-get install -y libcurl4-openssl-dev
@@ -48,6 +49,7 @@ jobs:
           git reset --hard 8fbfdb6
           cmake -DBUILD_SAMPLES=on -H. -Bbuild
           make -C build install
+
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:
@@ -131,6 +133,12 @@ jobs:
         with:
           command: test
           args: --no-default-features --features=eaa_kbc
+
+      - name: Run cargo test - cc-kbc-occlum
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=cc_kbc_occlum
 
       - name: Run cargo test - default
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,14 @@ edition = "2018"
 anyhow = ">=1.0"
 aes = { version = ">=0.8", optional = true }
 async-trait = { version = "0.1.61", optional = true }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", rev = "80b84cf", optional = true  }
 base64 = "0.13"
 base64-serde = { version = "0.6", optional = true }
 cfg-if = "1.0.0"
 ctr = { version = ">=0.9", optional = true }
 hmac = { version = ">=0.12", optional = true }
 josekit = { version = ">=0.7", optional = true }
+kbc = { git = "https://github.com/confidential-containers/attestation-agent.git", rev = "80b84cf", optional = true  }
 lazy_static = ">=1.4"
 openssl = { version = ">=0.10", features = ["vendored"], optional = true }
 pin-project-lite = { version = "0.2.9", optional = true }
@@ -30,7 +32,6 @@ sha2 = { version = ">=0.10", optional = true }
 tokio = { version = "1.17.0", features = ["rt-multi-thread"], optional = true }
 tonic = { version = ">=0.8.0", optional = true }
 ttrpc = { version = "0.7.1", features = ["async"], default-features = false, optional = true }
-attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", tag = "v0.5.0", optional = true  }
 
 [build-dependencies]
 tonic-build = {version = "0.8.0", optional = true }
@@ -43,7 +44,13 @@ tokio = { version = "1.17.0", features = ["time", "signal"] }
 
 [features]
 default = ["block-cipher-openssl", "keywrap-jwe", "keywrap-keyprovider-cmd"]
+
+# Use eaa kbc to request KEK
 eaa_kbc = ["keywrap-keyprovider-native", "attestation_agent/eaa_kbc"]
+
+# Use cc kbc + occlum to request KEK
+cc_kbc_occlum = ["keywrap-keyprovider-native", "attestation_agent/cc_kbc", "attestation_agent/occlum-attester"]
+
 async-io = ["tokio"]
 
 block-cipher = []


### PR DESCRIPTION
`cc_kbc_occlum` enables occlum attester and cc-kbc in attestation-agent dependency, which can be used in enclave-cc to support occlum attester.

CI also updated to test this new feature.